### PR TITLE
phpコンテナの整備

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -17,11 +17,22 @@ RUN set -eux && \
   php -r "unlink('composer-setup.php');" && \
   mv composer.phar /usr/local/bin/composer && \
   apk update && \
-  apk add --update --no-cache icu-dev libzip-dev autoconf gcc g++ make git zip unzip tzdata && \
+  apk upgrade && \
+  apk add --update --no-cache --virtual=.build-dependencies \
+    autoconf \
+    gcc \
+    g++ \
+    make \
+    tzdata && \
+  apk add --update --no-cache \
+    icu-dev \
+    libzip-dev \
+    zip \
+    unzip && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   echo "Asia/Tokyo" > /etc/timezone && \
   pecl install xdebug && \
-  apk del autoconf gcc g++ make tzdata && \
+  apk del .build-dependencies && \
   docker-php-ext-install intl pdo_mysql mbstring zip bcmath && \
   docker-php-ext-enable xdebug && \
   composer config -g repos.packagist composer https://packagist.jp && \

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -15,7 +15,6 @@ mbstring.internal_encoding = "UTF-8"
 mbstring.language = "Japanese"
 
 [xdebug]
-zend_extension = /usr/local/lib/php/extensions/no-debug-non-zts-20180731/xdebug.so
 xdebug.remote_enable = 1
 xdebug.remote_autostart = 1
 xdebug.remote_host = host.docker.internal


### PR DESCRIPTION
- xdebug の zend_extension が `/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini`
の記述と重複となるので削除
- `--virtual` オプションでグルーピング

## 参考

- https://qiita.com/KazuyaHara/items/6c66f5e77d208c85f143