### PR TITLE
web(nginx)コンテナのイメージをDebianからAlpineに変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   web:
-    image: nginx
+    image: nginx:alpine
     depends_on:
       - app
     ports:


### PR DESCRIPTION
## 概要

Dockerイメージの容量削減のため、web(nginx)コンテナのイメージをDebianからAlpineに変更