### PR TITLE
コマンド実行履歴の永続化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /.vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json
+/docker/ash/.ash_history
 /logs/*

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ http://127.0.0.1:3500
 ### Running Migrations
 
 ```
-$ docker-compose exec app ash
+$ docker-compose exec app ash -l
 $ sed -i -e "s/DB_HOST=.*/DB_HOST=db/" .env
 $ php artisan migrate
 ```
@@ -46,7 +46,7 @@ $ php artisan migrate
 ### Running Testings
 
 ```
-$ docker-compose exec app ash
+$ docker-compose exec app ash -l
 $ cp .env.example .env.testing
 $ php artisan key:generate --env testing
 $ sed -i -e "s/DB_HOST=.*/DB_HOST=db-testing/" .env.testing
@@ -56,7 +56,7 @@ $ ./vendor/bin/phpunit
 ### Send Test Mail
 
 ```
-$ docker-compose exec app ash
+$ docker-compose exec app ash -l
 $ sed -i -e "s/MAIL_HOST=.*/MAIL_HOST=mail/" .env
 $ sed -i -e "s/MAIL_PORT=.*/MAIL_PORT=1025/" .env
 
@@ -67,14 +67,6 @@ Mail::raw('test mail',function($message){$message->to('test@example.com')->subje
 http://127.0.0.1:3504
 
 ## As necessary
-
-### Login shell of the app container
-
-```
-$ docker-compose exec app ash -l
-```
-
-[alias settings](docker/php/aliases.sh) is enabled by `-l` option.
 
 ### MySQL connection
 
@@ -100,7 +92,7 @@ $ docker-compose run node yarn run dev
 ### Redis for Laravel
 
 ```
-$ docker-compose exec app ash
+$ docker-compose exec app ash -l
 $ composer require predis/predis
 $ sed -i -e 's/REDIS_HOST=.*/REDIS_HOST=redis/' .env
 $ sed -i -e 's/CACHE_DRIVER=.*/CACHE_DRIVER=redis/' .env
@@ -114,7 +106,7 @@ Redis::get('name');
 ### Redis cli
 
 ```
-$ docker-compose exec redis ash
+$ docker-compose exec redis ash -l
 $ redis-cli
 ```
 

--- a/docker/ash/color_prompt.sh
+++ b/docker/ash/color_prompt.sh
@@ -9,3 +9,6 @@ if [ "$USERNAME" = root ]; then
 else
   PS1="[$GREEN\u@\h $NORMAL\W$GREEN]# $NORMAL"
 fi
+
+export HISTFILE=/etc/profile.d/.ash_history
+touch $HISTFILE


### PR DESCRIPTION
## 概要

dockerを構築する度にコマンド実行履歴がクリアされてしまうので `.ash_history` の永続化を行う。

## 補足

- https://stackoverflow.com/questions/28279862/docker-and-bash-history
