### PR TITLE
fix tzdata2019 to tzdata2020

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -21,7 +21,7 @@ RUN apk update && \
     gcc=~9.2 \
     g++=~9.2 \
     make=~4.2 \
-    tzdata=2019c-r0 \
+    tzdata=2020a-r0 \
     git=~2.24 && \
   apk add --update --no-cache \
     icu-dev=~64.2 \


### PR DESCRIPTION
クローンして実行した自環境では
`ERROR: unsatisfiable constraints:tzdata-2020a-r0:`
と表示されたので、パッケージバージョンを修正しました。